### PR TITLE
Wrapped touchRead with updated button class

### DIFF
--- a/teensy/podium_code/AnalogInputButton.h
+++ b/teensy/podium_code/AnalogInputButton.h
@@ -1,0 +1,172 @@
+#ifndef __ANALOG_INPUT_BUTTON_H__
+#define __ANALOG_INPUT_BUTTON_H__
+
+struct AnalogInputButtonInit {
+  int32_t threshold; //turn on @ baseline+threshold+hysteresis, off @baseline+threshold-hysteresis. Threshold can be negative
+  uint32_t hysteresis; //see above, adjusts threshold for noise immunity
+  uint32_t baseline_period_ticks; //how often to increment/decrement baseline in ticks
+  bool baseline_always; //adjust baseline regardless of sensor state and noise level
+  uint32_t timeout_ticks; //if nonzero, max sensor on time in ticks. Sensor state and baseline will reset if on that long.
+  uint32_t noise; //noise level for baseline adjustent, unless baseline_always
+};
+
+class AnalogInputButton {
+  public:
+    AnalogInputButton(const AnalogInputButtonInit *const init)
+    : mInitialized(false)
+    , mSwitchState(false)
+    , mChanged(false)
+    , mLastResult(0)
+    , mBaseline(0) 
+    , mThreshold(init->threshold)
+    , mHysteresis(init->hysteresis)
+    , mNoise(init->noise)
+    , mBaselineCount(0) 
+    , mBaselineRate(init->baseline_period_ticks)
+    , mBaselineAlways(init->baseline_always)
+    , mTimeOn(0)
+    , mTimeoutTicks(init->timeout_ticks) {
+    }
+
+    bool Update(const int32_t value) {
+      mLastResult = value;
+
+      //check baseline initialization flag
+      //reset baseline value if flag is unset
+      if (!mInitialized) {
+        mBaseline=mLastResult;
+        mInitialized=true;
+        mBaselineCount=0;
+      }
+
+      //compute sensor level as difference between raw and baseline
+      //if threshold negative, reverse sign and do everything else as though threshold positive
+      const int32_t difference = mLastResult - mBaseline * (mThreshold > 0 ? 1 : -1);
+
+      //adjust baseline
+      //Baseline drifts toward result value when switch off or mBaselineAlways set
+      //baseline not affected while switch on if mBaselineAlways is false
+      //Baseline adjustment rate determined by mBaselineRate
+      mBaselineCount = (mBaselineCount+1) % mBaselineRate;
+      if (mBaselineCount==0 && (mBaselineAlways || abs(difference) < mNoise)) {
+
+        //reset baseline if negative by more than threshold value
+        if (difference < -mThreshold) {
+          mBaseline=mLastResult;
+        } else {
+          mBaseline += difference > 0 ? 1 :
+                       (difference < 0 ? -1 : 0);
+        }
+      }
+
+      //Check switch state
+      if (!mSwitchState && difference > (mThreshold+mHysteresis)) {
+        mSwitchState = true;
+        mChanged = true;
+        mTimeOn = 0;
+      } else if (mSwitchState && difference < (mThreshold-mHysteresis)) {
+        mSwitchState=false;
+        mChanged=true;
+      } else {
+      }
+
+      //if on, check timeout
+      if (mSwitchState && mTimeoutTicks!=0) {
+        
+        if (mTimeOn > mTimeoutTicks) {
+          //flag to reset next time around
+          mInitialized=false;
+        }
+      }
+
+      //increment on time counter
+      if (mSwitchState) {
+        mTimeOn += 1;
+      }
+
+      return mSwitchState;
+    }
+
+    bool State() const {
+      return mSwitchState;
+    }
+
+    bool Changed() {
+      bool rVal=mChanged;
+      mChanged=false;
+      return rVal;
+    }
+
+    int32_t LastResult() const {
+      return mLastResult;
+    }
+
+    int32_t Baseline() const {
+      return mBaseline;
+    }
+
+    void ResetBaseline() {
+      mInitialized=0;
+    }
+
+    int32_t Diff() const {
+      return LastResult() - Baseline();
+    }
+
+    uint16_t BaselineRate() const {
+      return mBaselineRate;
+    }
+
+    void SetBaselineRate (const uint16_t val) {
+      mBaselineRate=val;
+    }
+
+    int32_t Hysteresis() const {
+      return mHysteresis;
+    }
+
+    void SetHysteresis(const int32_t val) {
+      if (val<0) {
+        mHysteresis=0;
+      } else {
+        mHysteresis=val;
+      }
+    }
+
+    uint32_t TimeoutTicks() const {
+      return mTimeoutTicks;
+    }
+
+    void SetTimeoutTicks(const uint32_t val) {
+      mTimeoutTicks=val;
+    }
+
+    bool BaselineAlways() const {
+      return mBaselineAlways;
+    }
+
+    void SetBaselineAlways(const bool val) {
+      mBaselineAlways=val;
+    }
+
+  private:
+    bool mInitialized; //has the baseline been initialized? Also used for reset.
+    bool mSwitchState; //Is the switch off or on?
+    bool mChanged; //Did the switch state just change?
+
+    int32_t mLastResult; //Last raw result value from sensor.
+    int32_t mBaseline; //Sensor baseline value.
+    int32_t mThreshold; //on/off threshold
+    int32_t mHysteresis; //on/off hysteresis
+    int32_t mNoise;
+
+    int32_t mBaselineCount; //counter to control baseline adjustment rate
+    int32_t mBaselineRate; //baseline adjustment counter period
+
+    bool mBaselineAlways;
+
+    uint32_t mTimeOn;
+    uint32_t mTimeoutTicks;
+};
+
+#endif //#ifndef __ANALOG_INPUT_BUTTON_H__

--- a/teensy/podium_code/AnalogInputButton.h
+++ b/teensy/podium_code/AnalogInputButton.h
@@ -48,12 +48,11 @@ class AnalogInputButton {
       //baseline not affected while switch on if mBaselineAlways is false
       //Baseline adjustment rate determined by mBaselineRate
       mBaselineCount = (mBaselineCount+1) % mBaselineRate;
-      if (mBaselineCount==0 && (mBaselineAlways || abs(difference) < mNoise)) {
-
-        //reset baseline if negative by more than threshold value
+      if (mBaselineCount==0) {
+        //neg reset
         if (difference < -mThreshold) {
-          mBaseline=mLastResult;
-        } else {
+          mInitialized = false;
+        } else if (mBaselineAlways || abs(difference) < mNoise) {
           mBaseline += difference > 0 ? 1 :
                        (difference < 0 ? -1 : 0);
         }

--- a/teensy/podium_code/podium_code.ino
+++ b/teensy/podium_code/podium_code.ino
@@ -14,9 +14,11 @@ const AnalogInputButtonInit btn_init = {
   .threshold = 200,
   .hysteresis = 50,
   .baseline_period_ticks = 100,
-  .baseline_always = false,
+  .baseline_always = true,
   .timeout_ticks = 1000,
-  .noise = 10
+  .noise = 10,
+  .neg_reset_periods = 5,
+  .debounce_ticks = 5,
 };
 
 AnalogInputButton cap_button(&btn_init);

--- a/teensy/podium_code/podium_code.ino
+++ b/teensy/podium_code/podium_code.ino
@@ -1,28 +1,47 @@
+#include "AnalogInputButton.h"
+
 int noteNumber = 1; //change per teensy
 
 int sensorPin = 15;
-bool pinState;
-bool noteState;
-unsigned long lastDebounce;
-unsigned long debounceDelay = 20;
-int targetRange = 3000; // Capacitance threshold == touched
 
+//adjust these values for the sensitivity and environment of your sensor
+//the threshold should be slightly lower than the lowest change you want to cause a turn-on
+//the hysteresis should be set at a high enough level to prevent unwanted turn-offs when when the sensor is on
+//baseline_period_ticks and timeout_ticks are in units of your refresh period (e.g., you sample the sensor every 10 ms, timeout_ticks = 1000 means 10 seconds)
+//noise should be set at how much noise, +/-, you get with the sensor off. The baseline level will update if the sensor value is within current value +/- noise.
+//if baseline_always is on, noise is ignored, and the baseline will adjust regardless of the on/off state or current level
+const AnalogInputButtonInit btn_init = {
+  .threshold = 200,
+  .hysteresis = 50,
+  .baseline_period_ticks = 100,
+  .baseline_always = false,
+  .timeout_ticks = 1000,
+  .noise = 10
+};
+
+AnalogInputButton cap_button(&btn_init);
 
 void setup() {
   Serial.begin(9600);
 }
 
 void loop() {
-//  Serial.println(touchRead(sensorPin));
-  bool tripped = touchRead(sensorPin) > targetRange;
-  if (pinState != tripped) {
-    lastDebounce = millis();
-    pinState = tripped;
+  const int level = touchRead(sensorPin);
+  
+  const bool state = cap_button.Update(level);
+  const bool changed = cap_button.Changed();
+
+  if (changed) {
+    const uint8_t vel = state ? 127 : 0;
+    usbMIDI.sendNoteOn(noteNumber, vel, 1);
+    Serial.println(vel);
   }
-  else if (noteState != pinState && (millis() - lastDebounce) > debounceDelay) {
-    usbMIDI.sendNoteOn(noteNumber, pinState ? 127 : 0, 1);
-    Serial.println(pinState);
-    noteState = pinState;
-  }
+  
+  Serial.print(level);
+  Serial.print(" ");
+  Serial.print(cap_button.Baseline());
+  Serial.print(" ");
+  Serial.println(state);
+
   delay(10);        // delay in between reads for stability
 }


### PR DESCRIPTION
I modified my capsensor library to abstract out the actual cap sensor read, and I updated your podium_code sketch to use it (now called AnalogInputButton). I'm still calling touchRead to get the level, but I immediately pass it to an AnalogInputButton to track baseline and update button state.

There's an init struct that sets several parameters for the AnalogInputButton along with some comments that I hope help.

The one thing missing is any time based debouncing. It might not be necessary, but I'll add it to the library if I get time. Testing with the teensy I have here, it's working great as is.

The parameters will probably need tweaking for your setup.